### PR TITLE
Remove testing pkg dependency

### DIFF
--- a/flow.go
+++ b/flow.go
@@ -226,6 +226,19 @@ func (f *Flow) Test(conn Conn) error {
 	return nil
 }
 
+func (f *Flow) TestAsync(conn Conn, timeout time.Duration) <-chan error {
+	errCh := make(chan error, 1)
+	go func() {
+		select {
+		case <-time.After(timeout):
+			errCh <- errors.New("timed out waiting for flow to complete")
+		case errCh <- f.Test(conn):
+		}
+	}()
+
+	return errCh
+}
+
 // add will add the specified action.
 func (f *Flow) add(action *action) {
 	f.actions = append(f.actions, action)

--- a/flow.go
+++ b/flow.go
@@ -188,12 +188,12 @@ func (f *Flow) Test(conn Conn) error {
 		case actionSend:
 			err := conn.Send(action.packet)
 			if err != nil {
-				return err
+				return fmt.Errorf("error sending packet: %v", err)
 			}
 		case actionReceive:
 			pkt, err := conn.Receive()
 			if err != nil {
-				return err
+				return fmt.Errorf("expected to receive a packet but got error: %v", err)
 			}
 
 			if want, got := action.packet.String(), pkt.String(); want != got {
@@ -202,7 +202,7 @@ func (f *Flow) Test(conn Conn) error {
 		case actionSkip:
 			_, err := conn.Receive()
 			if err != nil {
-				return err
+				return fmt.Errorf("expected to skip over a received packet but got error: %v", err)
 			}
 		case actionWait:
 			<-action.ch
@@ -213,7 +213,7 @@ func (f *Flow) Test(conn Conn) error {
 		case actionClose:
 			err := conn.Close()
 			if err != nil {
-				return err
+				return fmt.Errorf("expected connection to close successfully but got error: %v", err)
 			}
 		case actionEnd:
 			_, err := conn.Receive()

--- a/flow_test.go
+++ b/flow_test.go
@@ -59,20 +59,13 @@ func TestFlow(t *testing.T) {
 
 	pipe := NewPipe()
 
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- server.Test(pipe)
-	}()
+	errCh := server.TestAsync(pipe, 100*time.Millisecond)
 
 	err := client.Test(pipe)
 	assert.NoError(t, err)
 
-	select {
-	case err := <-errCh:
-		assert.NoError(t, err)
-	case <-time.After(500 * time.Millisecond):
-		assert.Fail(t, "timed out waiting for server flow to complete")
-	}
+	err = <-errCh
+	assert.NoError(t, err)
 }
 
 func TestAlreadyClosedError(t *testing.T) {


### PR DESCRIPTION
This PR removes the dependency on the `testing` package.

Besides unnecessarily linking the `testing` package at compile time, this also has the unpleasant side effect of polluting the flags of any importers of the `tools` package with the flags from the `testing` package, e.g. `test.coverprofile`.

<img width="560" alt="screen shot 2017-06-13 at 2 09 32 pm" src="https://user-images.githubusercontent.com/213/27070460-acca525c-504b-11e7-85bc-8bafba324bac.png">

An example of client code that would benefit would be https://github.com/gomqtt/broker/blob/df763e26f52016616a6d00ae2797212f80c15d0d/backend.go#L97-L99, where we use `tools.NewTree()`. Any users of `github.com/gomqtt/broker` are now "forced" to link in the `testing` package into their binaries.